### PR TITLE
Rename concatinator function to be more discriptive

### DIFF
--- a/src/lib/array.c
+++ b/src/lib/array.c
@@ -38,6 +38,7 @@
 #define FI_INITIAL_ARRAY_ALLOC_SIZE (1 << 4)
 
 /* Prototypes */
+
 static bool fi_array_expand_container(struct FiArray *cur, size_t n);
 static bool fi_array_data_copy(const void *const src, void *dest, unsigned n);
 

--- a/src/lib/debug.h
+++ b/src/lib/debug.h
@@ -79,7 +79,7 @@ void _fi_log_message(FiDebugLevel level,
 #define fi_log_message(lv, fmt) do {                   \
                 if (FI_DEBUG_LEVEL <= (lv))                 \
                     _fi_log_message((lv),                   \
-                    __FUNC__, __LINE__, __FILENAME__, fmt); \
+                    __FUNC__, __LINE__, __FILENAME__, (fmt)); \
             } while(0)
 
 FI_END_DECLS

--- a/src/lib/file-manager.c
+++ b/src/lib/file-manager.c
@@ -99,7 +99,7 @@ bool fi_file_manager_read_dir(const char       *const path,
             fi_file_container_push(con, &file);
             if (recursive && file.type == FI_FILE_TYPE_DIRECTORY) {
                 // Add directory content recursively
-                char *full_filename = fi_strconcat(3, lpath, path_sep, dp->d_name);
+                char *full_filename = fi_strnconcat(3, lpath, path_sep, dp->d_name);
                 fi_file_manager_read_dir(full_filename, con, recursive);
                 free(full_filename);
             }
@@ -119,7 +119,7 @@ static bool read_file_info(const char *const path,
     // Read the file information by lstat
     struct stat st_buff;
     char path_sep[] = {path_separator, '\0'};
-    char *fullpath = fi_strconcat(3, path, path_sep, filename);
+    char *fullpath = fi_strnconcat(3, path, path_sep, filename);
     if (! fullpath)
         return false;
 

--- a/src/lib/file.c
+++ b/src/lib/file.c
@@ -139,7 +139,7 @@ void fi_file_set_props(struct FiFileInfo *file,
 {
         file->filename = fi_strndup(filename, fi_strlen(filename));
         file->path = fi_strndup(path, fi_strlen(path));
-        file->full_filename = fi_strconcat(
+        file->full_filename = fi_strnconcat(
                        2,
                        path,
                        file->filename);

--- a/src/lib/util-string.c
+++ b/src/lib/util-string.c
@@ -124,7 +124,7 @@ char *_fi_strndup(const char *src, size_t n)
 }
 #endif
 
-char* fi_strconcat(const unsigned char num, ...)
+char* fi_strnconcat(const unsigned char num, ...)
 {
     if (num < 1)
         return NULL;

--- a/src/lib/util-string.h
+++ b/src/lib/util-string.h
@@ -52,7 +52,7 @@ FI_BEGIN_DECLS
 char *fi_rtrim(char * str, const char * impurities);
 char *fi_ltrim(char * str, const char * impurities);
 char *fi_trim(char * str, const char * impurities);
-char *fi_strconcat(const unsigned char num, ...);
+char *fi_strnconcat(const unsigned char num, ...);
 int fi_strcmp0(const char *const s1, const char *const s2);
 char *itoa(const int i, char *str, unsigned base);
 

--- a/test/lib/test-file-manager.c
+++ b/test/lib/test-file-manager.c
@@ -43,7 +43,7 @@ FI_TEST_RESULT test_init()
     char *test_path = NULL;
     
     getcwd(pwd, DIR_PATH_MAX);
-    test_path = fi_strconcat(2, pwd, "/test/fs/");
+    test_path = fi_strnconcat(2, pwd, "/test/fs/");
     
     fi_file_manager_read_dir(test_path, con, true);
     fi_return_fail_if_not(NULL != con, "Failed to create new container");

--- a/test/lib/test-util-string.c
+++ b/test/lib/test-util-string.c
@@ -82,7 +82,7 @@ FI_TEST_RESULT test_string_concatenation()
     const char word2[] = "sed do eiusmod tempor incididunt ut labore et dolore ";
     const char word3[] = "Sed ut perspiciatis unde omnis iste natus ";
 
-    char * new_string = fi_strconcat(3, word1, word2, word3);
+    char * new_string = fi_strnconcat(3, word1, word2, word3);
     fi_return_fail_if_not(NULL != new_string, "Failed to create string");
 
     free (new_string);


### PR DESCRIPTION
In keeping with other string manuipulation function, the fi_strconcat was
renamted to 'fi_strnconcat' to be more explicit as to the need for the numeric
oprand